### PR TITLE
Revert "test2"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,3 @@ raml-server api.raml
 
 # test response:
 curl http://localhost:3000/people
-
-abc test


### PR DESCRIPTION
Reverts 6c697a61/raml-example#2
Failed enforcing status checks
